### PR TITLE
it should be 409 instead of 403

### DIFF
--- a/ldp.js
+++ b/ldp.js
@@ -33,6 +33,12 @@ function Ldp (rdf, store, options) {
     err.status = err.statusCode = 406;
     next(err);
   };
+  
+  self.error.conflict = function (req, res, next) {
+    var err = new Error('Conflict');
+    err.status = err.statusCode = 409;
+    next(err);
+  };
 
   self.log = 'log' in options ? options.log : function () {};
   self.defaultAgent = 'defaultAgent' in options ? options.defaultAgent : null;
@@ -191,7 +197,7 @@ function Ldp (rdf, store, options) {
 
         store.add(iri, graph, function (added) {
           if (added == null) {
-            return self.error.forbidden(req, res, next);
+            return self.error.conflict(req, res, next);
           }
 
           res.statusCode = 204; // No Content


### PR DESCRIPTION
The idea is that 409 is Conflict, 403 is Forbidden. This is not a forbidden operation, it just happen to be a conflict

See [LDP spec#4.2.4.3](http://www.w3.org/TR/ldp/#h-ldpr-http_put)

and 

See [LDP spec#5.2.4.1](http://www.w3.org/TR/ldp/#h-ldpc-http_put)

>  LDP servers should not allow HTTP PUT to update a LDPC’s containment triples; if the server receives such a request, it should respond with a 409 (Conflict) status code 
