### PR TITLE
[arguable] failure to delete a resource

### DIFF
--- a/ldp.js
+++ b/ldp.js
@@ -205,7 +205,7 @@ function Ldp (rdf, store, options) {
   self.del = function (req, res, next, iri, options) {
     store.delete(iri, function (success) {
       if (!success) {
-        return self.error.forbidden(req, res, next);
+        return self.error.notFound(req, res, next);
       }
 
       res.statusCode = 204; // No Content


### PR DESCRIPTION
Failing to delete a resource is in most of the cases a 404, however since we don't pass the error here, we can't really determine, so I think we should start by passing the error (and actually doing the error trick present in ldnode), maybe we shall discuss this on gitter before moving on

See 6.2.3 at http://www.w3.org/TR/ldp/#h-specs-http
